### PR TITLE
 Refer to this project by appropriate path

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -34,8 +34,8 @@ import (
 	"fmt"
 	"sync"
 
-	"gopkg.in/mgo.v2-unstable/bson"
-	"gopkg.in/mgo.v2-unstable/internal/scram"
+	"github.com/ContextLogic/mgo/bson"
+	"github.com/ContextLogic/mgo/internal/scram"
 )
 
 type authCmd struct {

--- a/auth_test.go
+++ b/auth_test.go
@@ -39,7 +39,8 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/mgo.v2-unstable"
+
+	"github.com/ContextLogic/mgo"
 )
 
 func (s *S) TestAuthLoginDatabase(c *C) {

--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -40,8 +40,9 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/mgo.v2-unstable/bson"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/ContextLogic/mgo/bson"
 )
 
 func TestAll(t *testing.T) {

--- a/bson/decimal_test.go
+++ b/bson/decimal_test.go
@@ -1,4 +1,4 @@
-﻿// BSON library for Go
+// BSON library for Go
 //
 // Copyright (c) 2010-2012 - Gustavo Niemeyer <gustavo@niemeyer.net>
 //
@@ -33,9 +33,9 @@ import (
 	"regexp"
 	"strings"
 
-	"gopkg.in/mgo.v2-unstable/bson"
-
 	. "gopkg.in/check.v1"
+
+	"github.com/ContextLogic/mgo/bson"
 )
 
 // --------------------------------------------------------------------------

--- a/bson/json.go
+++ b/bson/json.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"gopkg.in/mgo.v2-unstable/internal/json"
 	"strconv"
 	"time"
+
+	"github.com/ContextLogic/mgo/internal/json"
 )
 
 // UnmarshalJSON unmarshals a JSON value that may hold non-standard

--- a/bson/json_test.go
+++ b/bson/json_test.go
@@ -1,12 +1,13 @@
 package bson_test
 
 import (
-	"gopkg.in/mgo.v2-unstable/bson"
-
-	. "gopkg.in/check.v1"
 	"reflect"
 	"strings"
 	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/ContextLogic/mgo/bson"
 )
 
 type jsonTest struct {

--- a/bulk.go
+++ b/bulk.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"sort"
 
-	"gopkg.in/mgo.v2-unstable/bson"
+	"github.com/ContextLogic/mgo/bson"
 )
 
 // Bulk represents an operation that can be prepared with several

--- a/bulk_test.go
+++ b/bulk_test.go
@@ -28,7 +28,8 @@ package mgo_test
 
 import (
 	. "gopkg.in/check.v1"
-	"gopkg.in/mgo.v2-unstable"
+
+	"github.com/ContextLogic/mgo"
 )
 
 func (s *S) TestBulkInsert(c *C) {

--- a/cluster.go
+++ b/cluster.go
@@ -30,12 +30,12 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
-	"gopkg.in/mgo.v2-unstable/bson"
-	"strconv"
-	"strings"
+	"github.com/ContextLogic/mgo/bson"
 )
 
 // ---------------------------------------------------------------------------

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -35,8 +35,9 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/mgo.v2-unstable"
-	"gopkg.in/mgo.v2-unstable/bson"
+
+	"github.com/ContextLogic/mgo"
+	"github.com/ContextLogic/mgo/bson"
 )
 
 func (s *S) TestNewSession(c *C) {
@@ -1476,7 +1477,6 @@ func (s *S) TestSecondaryModeWithMongosInsert(c *C) {
 	coll.Find(nil).One(&result)
 	c.Assert(result.A, Equals, 1)
 }
-
 
 func (s *S) TestRemovalOfClusterMember(c *C) {
 	if *fast {

--- a/dbtest/dbserver.go
+++ b/dbtest/dbserver.go
@@ -9,8 +9,9 @@ import (
 	"strconv"
 	"time"
 
-	"gopkg.in/mgo.v2-unstable"
-	"gopkg.in/tomb.v2"
+	tomb "gopkg.in/tomb.v2"
+
+	"github.com/ContextLogic/mgo"
 )
 
 // DBServer controls a MongoDB server process to be used within test suites.

--- a/dbtest/dbserver_test.go
+++ b/dbtest/dbserver_test.go
@@ -7,8 +7,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/mgo.v2-unstable"
-	"gopkg.in/mgo.v2-unstable/dbtest"
+	"github.com/ContextLogic/mgo"
+	"github.com/ContextLogic/mgo/dbtest"
 )
 
 type M map[string]interface{}

--- a/gridfs.go
+++ b/gridfs.go
@@ -36,7 +36,7 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/mgo.v2-unstable/bson"
+	"github.com/ContextLogic/mgo/bson"
 )
 
 type GridFS struct {

--- a/gridfs_test.go
+++ b/gridfs_test.go
@@ -32,8 +32,9 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/mgo.v2-unstable"
-	"gopkg.in/mgo.v2-unstable/bson"
+
+	"github.com/ContextLogic/mgo"
+	"github.com/ContextLogic/mgo/bson"
 )
 
 func (s *S) TestGridFSCreate(c *C) {

--- a/internal/scram/scram_test.go
+++ b/internal/scram/scram_test.go
@@ -2,11 +2,12 @@ package scram_test
 
 import (
 	"crypto/sha1"
+	"strings"
 	"testing"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/mgo.v2-unstable/internal/scram"
-	"strings"
+
+	"github.com/ContextLogic/mgo/internal/scram"
 )
 
 var _ = Suite(&S{})

--- a/server.go
+++ b/server.go
@@ -33,7 +33,7 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/mgo.v2-unstable/bson"
+	"github.com/ContextLogic/mgo/bson"
 )
 
 // ---------------------------------------------------------------------------

--- a/session.go
+++ b/session.go
@@ -41,7 +41,7 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/mgo.v2-unstable/bson"
+	"github.com/ContextLogic/mgo/bson"
 )
 
 type Mode int

--- a/session_test.go
+++ b/session_test.go
@@ -38,8 +38,9 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/mgo.v2-unstable"
-	"gopkg.in/mgo.v2-unstable/bson"
+
+	"github.com/ContextLogic/mgo"
+	"github.com/ContextLogic/mgo/bson"
 )
 
 func (s *S) TestRunString(c *C) {
@@ -4159,11 +4160,11 @@ func (s *S) TestBypassValidation(c *C) {
 
 func (s *S) TestVersionAtLeast(c *C) {
 	tests := [][][]int{
-		{{3,2,1}, {3,2,0}},
-		{{3,2,1}, {3,2}},
-		{{3,2,1}, {2,5,5,5}},
-		{{3,2,1}, {2,5,5}},
-		{{3,2,1}, {2,5}},
+		{{3, 2, 1}, {3, 2, 0}},
+		{{3, 2, 1}, {3, 2}},
+		{{3, 2, 1}, {2, 5, 5, 5}},
+		{{3, 2, 1}, {2, 5, 5}},
+		{{3, 2, 1}, {2, 5}},
 	}
 	for _, pair := range tests {
 		bi := mgo.BuildInfo{VersionArray: pair[0]}

--- a/socket.go
+++ b/socket.go
@@ -33,7 +33,7 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/mgo.v2-unstable/bson"
+	"github.com/ContextLogic/mgo/bson"
 )
 
 type replyFunc func(err error, reply *replyOp, docNum int, docData []byte)

--- a/suite_test.go
+++ b/suite_test.go
@@ -39,8 +39,9 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/mgo.v2-unstable"
-	"gopkg.in/mgo.v2-unstable/bson"
+
+	"github.com/ContextLogic/mgo"
+	"github.com/ContextLogic/mgo/bson"
 )
 
 var fast = flag.Bool("fast", false, "Skip slow tests")

--- a/txn/debug.go
+++ b/txn/debug.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"sync/atomic"
 
-	"gopkg.in/mgo.v2-unstable/bson"
+	"github.com/ContextLogic/mgo/bson"
 )
 
 var (

--- a/txn/flusher.go
+++ b/txn/flusher.go
@@ -3,8 +3,8 @@ package txn
 import (
 	"fmt"
 
-	"gopkg.in/mgo.v2-unstable"
-	"gopkg.in/mgo.v2-unstable/bson"
+	"github.com/ContextLogic/mgo"
+	"github.com/ContextLogic/mgo/bson"
 )
 
 func flush(r *Runner, t *transaction) error {

--- a/txn/sim_test.go
+++ b/txn/sim_test.go
@@ -2,13 +2,15 @@ package txn_test
 
 import (
 	"flag"
-	"gopkg.in/mgo.v2-unstable"
-	"gopkg.in/mgo.v2-unstable/bson"
-	"gopkg.in/mgo.v2-unstable/dbtest"
-	"gopkg.in/mgo.v2-unstable/txn"
-	. "gopkg.in/check.v1"
 	"math/rand"
 	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/ContextLogic/mgo"
+	"github.com/ContextLogic/mgo/bson"
+	"github.com/ContextLogic/mgo/dbtest"
+	"github.com/ContextLogic/mgo/txn"
 )
 
 var (

--- a/txn/tarjan.go
+++ b/txn/tarjan.go
@@ -1,8 +1,9 @@
 package txn
 
 import (
-	"gopkg.in/mgo.v2-unstable/bson"
 	"sort"
+
+	"github.com/ContextLogic/mgo/bson"
 )
 
 func tarjanSort(successors map[bson.ObjectId][]bson.ObjectId) [][]bson.ObjectId {

--- a/txn/tarjan_test.go
+++ b/txn/tarjan_test.go
@@ -2,8 +2,10 @@ package txn
 
 import (
 	"fmt"
-	"gopkg.in/mgo.v2-unstable/bson"
+
 	. "gopkg.in/check.v1"
+
+	"github.com/ContextLogic/mgo/bson"
 )
 
 type TarjanSuite struct{}

--- a/txn/txn.go
+++ b/txn/txn.go
@@ -7,18 +7,17 @@
 package txn
 
 import (
+	crand "crypto/rand"
 	"encoding/binary"
 	"fmt"
+	mrand "math/rand"
 	"reflect"
 	"sort"
 	"strings"
 	"sync"
 
-	"gopkg.in/mgo.v2-unstable"
-	"gopkg.in/mgo.v2-unstable/bson"
-
-	crand "crypto/rand"
-	mrand "math/rand"
+	"github.com/ContextLogic/mgo"
+	"github.com/ContextLogic/mgo/bson"
 )
 
 type state int

--- a/txn/txn_test.go
+++ b/txn/txn_test.go
@@ -8,10 +8,11 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/mgo.v2-unstable"
-	"gopkg.in/mgo.v2-unstable/bson"
-	"gopkg.in/mgo.v2-unstable/dbtest"
-	"gopkg.in/mgo.v2-unstable/txn"
+
+	"github.com/ContextLogic/mgo"
+	"github.com/ContextLogic/mgo/bson"
+	"github.com/ContextLogic/mgo/dbtest"
+	"github.com/ContextLogic/mgo/txn"
 )
 
 func TestAll(t *testing.T) {


### PR DESCRIPTION
Previously this project had references to the upstream in its imports,
such as:

    import "gopkg.in/mgo.v2-unstable/bson"

This would cause $(go get), glide, and dep to transitively fetch the
upstream and cause build problems.

By universally referring to "github.com/ContextLogic/mgo/..." we fix
these build time issues at the cost of potentially needing to clean up
upstring commits as we pull them.