### PR TITLE
Close a socket if it's not going to be used

### DIFF
--- a/server.go
+++ b/server.go
@@ -228,6 +228,8 @@ func (server *mongoServer) RecycleSocket(socket *mongoSocket) {
 	server.Lock()
 	if !server.closed {
 		server.unusedSockets = append(server.unusedSockets, socket)
+	} else {
+		socket.Close()
 	}
 	server.Unlock()
 }


### PR DESCRIPTION
In trying to debug a (normal) increase in active sockets we noticed that
this might be a place from whence mgo might leak socket connections.