### PR TITLE
Only call close on the socket if it is non-nil

### DIFF
--- a/server.go
+++ b/server.go
@@ -369,8 +369,10 @@ func (server *mongoServer) pruner(loop bool, softPoolLimit int) {
 		server.Unlock()
 
 		for i, sock := range socketsToClose {
-			sock.Close()
-			socketsToClose[i] = nil
+			if sock != nil {
+				sock.Close()
+				socketsToClose[i] = nil
+			}
 		}
 
 		if !loop {


### PR DESCRIPTION
Throughout the mgo driver values of slices are set to nil in an attempt
to "help" GC. This means that most slices of things in mgo *might* be
nil.